### PR TITLE
fix missing build deps

### DIFF
--- a/logrotate.spec.in
+++ b/logrotate.spec.in
@@ -6,7 +6,7 @@ License: GPLv2+
 Group: System Environment/Base
 Source: https://github.com/logrotate/logrotate/releases/download/%{version}/logrotate-%{version}.tar.gz
 Requires: coreutils >= 5.92 libsepol libselinux popt
-BuildRequires: libselinux-devel popt-devel
+BuildRequires: libselinux-utils libselinux-devel popt-devel
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %{!?_licensedir:%global license %%doc}


### PR DESCRIPTION
`make test` tries to see whether SELinux is enabled using /usr/sbin/selinuxenabled, which is being shipped in libselinux-utils